### PR TITLE
feat: date library

### DIFF
--- a/date.libsonnet
+++ b/date.libsonnet
@@ -1,0 +1,35 @@
+local d = import 'doc-util/main.libsonnet';
+
+{
+  '#': d.pkg(
+    name='date',
+    url='github.com/jsonnet-libs/xtd/date.libsonnet',
+    help='`time` provides various date related functions.',
+  ),
+
+  local commonYearMonthLength = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+  local commonYearMonthOffset = [0, 3, 3, 6, 1, 4, 6, 2, 5, 0, 3, 5],
+  local leapYearMonthOffset = [0, 3, 4, 0, 2, 5, 0, 3, 6, 1, 4, 6],
+  local monthOffset(year, month) = if self.isLeapYear(year) then leapYearMonthOffset[month - 1]
+  else commonYearMonthOffset[month - 1],
+  '#isLeap': d.fn(
+    '`isLeap` returns true if the given year is a leap year.',
+    [d.arg('year', d.T.number)],
+  ),
+  isLeapYear(year):: year % 4 == 0 && (year % 100 != 0 || year % 400 == 0),
+
+  '#dayOfWeek': d.fn(
+    '`dayOfWeek` returns the day of the week for the given date. 0=Sunday, 1=Monday, etc.',
+    [d.arg('year', d.T.number), d.arg('month', d.T.number), d.arg('day', d.T.number)],
+  ),
+  dayOfWeek(year, month, day)::
+    (day + monthOffset(year, month) + 5 * ((year - 1) % 4) + 4 * ((year - 1) % 100) + 6 * ((year - 1) % 400)) % 7,
+
+  '#dayofYear': d.fn(
+    '`dayOfYear` returns the ordinal day of the year for the given date (1-365 for common years, 1-366 for leap years).',
+    [d.arg('year', d.T.number), d.arg('month', d.T.number), d.arg('day', d.T.number)],
+  ),
+  dayOfYear(year, month, day)::
+    std.foldl(function(a, b) a + b, std.slice(commonYearMonthLength, 0, month - 1, 1), 0) + day +
+    if month > 2 && self.isLeapYear(year) then 1 else 0,
+}

--- a/date.libsonnet
+++ b/date.libsonnet
@@ -48,7 +48,9 @@ local d = import 'doc-util/main.libsonnet';
   ),
   dayOfYear(year, month, day)::
     std.foldl(
-      function(a, b) a + b, std.slice(commonYearMonthLength, 0, month - 1, 1), 0
+      function(a, b) a + b,
+      std.slice(commonYearMonthLength, 0, month - 1, 1),
+      0
     ) + day +
     if month > 2 && self.isLeapYear(year)
     then 1

--- a/date.libsonnet
+++ b/date.libsonnet
@@ -7,29 +7,50 @@ local d = import 'doc-util/main.libsonnet';
     help='`time` provides various date related functions.',
   ),
 
+  // Lookup tables for calendar calculations
   local commonYearMonthLength = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
   local commonYearMonthOffset = [0, 3, 3, 6, 1, 4, 6, 2, 5, 0, 3, 5],
   local leapYearMonthOffset = [0, 3, 4, 0, 2, 5, 0, 3, 6, 1, 4, 6],
-  local monthOffset(year, month) = if self.isLeapYear(year) then leapYearMonthOffset[month - 1]
-  else commonYearMonthOffset[month - 1],
-  '#isLeap': d.fn(
-    '`isLeap` returns true if the given year is a leap year.',
+
+  // monthOffset looks up the offset to apply in day of week calculations based on the year and month
+  local monthOffset(year, month) =
+    if self.isLeapYear(year)
+    then leapYearMonthOffset[month - 1]
+    else commonYearMonthOffset[month - 1],
+
+  '#isLeapYear': d.fn(
+    '`isLeapYear` returns true if the given year is a leap year.',
     [d.arg('year', d.T.number)],
   ),
   isLeapYear(year):: year % 4 == 0 && (year % 100 != 0 || year % 400 == 0),
 
   '#dayOfWeek': d.fn(
     '`dayOfWeek` returns the day of the week for the given date. 0=Sunday, 1=Monday, etc.',
-    [d.arg('year', d.T.number), d.arg('month', d.T.number), d.arg('day', d.T.number)],
+    [
+      d.arg('year', d.T.number),
+      d.arg('month', d.T.number),
+      d.arg('day', d.T.number),
+    ],
   ),
   dayOfWeek(year, month, day)::
     (day + monthOffset(year, month) + 5 * ((year - 1) % 4) + 4 * ((year - 1) % 100) + 6 * ((year - 1) % 400)) % 7,
 
-  '#dayofYear': d.fn(
-    '`dayOfYear` returns the ordinal day of the year for the given date (1-365 for common years, 1-366 for leap years).',
-    [d.arg('year', d.T.number), d.arg('month', d.T.number), d.arg('day', d.T.number)],
+  '#dayOfYear': d.fn(
+    |||
+      `dayOfYear` calculates the ordinal day of the year based on the given date. The range of outputs is 1-365
+      for common years, and 1-366 for leap years.
+    |||,
+    [
+      d.arg('year', d.T.number),
+      d.arg('month', d.T.number),
+      d.arg('day', d.T.number),
+    ],
   ),
   dayOfYear(year, month, day)::
-    std.foldl(function(a, b) a + b, std.slice(commonYearMonthLength, 0, month - 1, 1), 0) + day +
-    if month > 2 && self.isLeapYear(year) then 1 else 0,
+    std.foldl(
+      function(a, b) a + b, std.slice(commonYearMonthLength, 0, month - 1, 1), 0
+    ) + day +
+    if month > 2 && self.isLeapYear(year)
+    then 1
+    else 0,
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,6 @@ in the future, but also provides a place for less general, yet useful utilities.
 * [aggregate](aggregate.md)
 * [ascii](ascii.md)
 * [camelcase](camelcase.md)
+* [date](date.md)
 * [inspect](inspect.md)
 * [url](url.md)

--- a/docs/date.md
+++ b/docs/date.md
@@ -1,0 +1,43 @@
+---
+permalink: /date/
+---
+
+# package date
+
+```jsonnet
+local date = import "github.com/jsonnet-libs/xtd/date.libsonnet"
+```
+
+`time` provides various date related functions.
+
+## Index
+
+* [`fn dayOfWeek(year, month, day)`](#fn-dayofweek)
+* [`fn dayofYear(year, month, day)`](#fn-dayofyear)
+* [`fn isLeap(year)`](#fn-isleap)
+
+## Fields
+
+### fn dayOfWeek
+
+```ts
+dayOfWeek(year, month, day)
+```
+
+`dayOfWeek` returns the day of the week for the given date. 0=Sunday, 1=Monday, etc.
+
+### fn dayofYear
+
+```ts
+dayofYear(year, month, day)
+```
+
+`dayOfYear` returns the ordinal day of the year for the given date (1-365 for common years, 1-366 for leap years).
+
+### fn isLeap
+
+```ts
+isLeap(year)
+```
+
+`isLeap` returns true if the given year is a leap year.

--- a/docs/date.md
+++ b/docs/date.md
@@ -13,8 +13,8 @@ local date = import "github.com/jsonnet-libs/xtd/date.libsonnet"
 ## Index
 
 * [`fn dayOfWeek(year, month, day)`](#fn-dayofweek)
-* [`fn dayofYear(year, month, day)`](#fn-dayofyear)
-* [`fn isLeap(year)`](#fn-isleap)
+* [`fn dayOfYear(year, month, day)`](#fn-dayofyear)
+* [`fn isLeapYear(year)`](#fn-isleapyear)
 
 ## Fields
 
@@ -26,18 +26,20 @@ dayOfWeek(year, month, day)
 
 `dayOfWeek` returns the day of the week for the given date. 0=Sunday, 1=Monday, etc.
 
-### fn dayofYear
+### fn dayOfYear
 
 ```ts
-dayofYear(year, month, day)
+dayOfYear(year, month, day)
 ```
 
-`dayOfYear` returns the ordinal day of the year for the given date (1-365 for common years, 1-366 for leap years).
+`dayOfYear` calculates the ordinal day of the year based on the given date. The range of outputs is 1-365
+for common years, and 1-366 for leap years.
 
-### fn isLeap
+
+### fn isLeapYear
 
 ```ts
-isLeap(year)
+isLeapYear(year)
 ```
 
-`isLeap` returns true if the given year is a leap year.
+`isLeapYear` returns true if the given year is a leap year.

--- a/main.libsonnet
+++ b/main.libsonnet
@@ -14,6 +14,7 @@ local d = import 'doc-util/main.libsonnet';
 
   aggregate: (import './aggregate.libsonnet'),
   ascii: (import './ascii.libsonnet'),
+  date: (import './date.libsonnet'),
   camelcase: (import './camelcase.libsonnet'),
   inspect: (import './inspect.libsonnet'),
   url: (import './url.libsonnet'),

--- a/test.jsonnet
+++ b/test.jsonnet
@@ -170,9 +170,85 @@ local TestInspect =
          : name('maxRecursionDepth');
   true;
 
+local TestIsLeapYear =
+  local name(case) = 'TestIsLeapYear:%s failed' % case;
 
+  assert !xtd.date.isLeapYear(1995)
+         : name('commonYear');
+
+  assert xtd.date.isLeapYear(1996)
+         : name('fourYearCycle');
+
+  assert xtd.date.isLeapYear(2000)
+         : name('fourHundredYearCycle');
+
+  assert !xtd.date.isLeapYear(2100)
+         : name('hundredYearCycle');
+
+  true;
+
+local TestDayOfWeek =
+  local name(case) = 'TestDayOfWeek:%s failed' % case;
+
+  assert xtd.date.dayOfWeek(2000, 1, 1)
+         == 6
+         : name('leapYearStart');
+
+  assert xtd.date.dayOfWeek(2000, 12, 31)
+         == 0
+         : name('leapYearEnd');
+
+  assert xtd.date.dayOfWeek(1995, 1, 1)
+         == 0
+         : name('commonYearStart');
+
+  assert xtd.date.dayOfWeek(2003, 12, 31)
+         == 3
+         : name('commonYearEnd');
+
+  assert xtd.date.dayOfWeek(2024, 7, 19)
+         == 5
+         : name('leapYearMid');
+
+  assert xtd.date.dayOfWeek(2023, 6, 15)
+         == 4
+         : name('commonYearMid');
+
+  true;
+
+local TestDayOfYear =
+  local name(case) = 'TestDayOfYear:%s failed' % case;
+
+  assert xtd.date.dayOfYear(2000, 1, 1)
+         == 1
+         : name('leapYearStart');
+
+  assert xtd.date.dayOfYear(2000, 12, 31)
+         == 366
+         : name('leapYearEnd');
+
+  assert xtd.date.dayOfYear(1995, 1, 1)
+         == 1
+         : name('commonYearStart');
+
+  assert xtd.date.dayOfYear(2003, 12, 31)
+         == 365
+         : name('commonYearEnd');
+
+  assert xtd.date.dayOfYear(2024, 7, 19)
+         == 201
+         : name('leapYearMid');
+
+  assert xtd.date.dayOfYear(2023, 6, 15)
+         == 166
+         : name('commonYearMid');
+
+  true;
 true
 && TestEscapeString
 && TestEncodeQuery
 && TestCamelCaseSplit
 && TestInspect
+&& TestIsLeapYear
+&& TestDayOfWeek
+&& TestDayOfYear


### PR DESCRIPTION
This PR adds a `date.libsonnet` library with 3 functions and associated unit tests in `test.jsonnet`:
- `date.isLeapYear(year)`: checks if year is a leap year, also used by the other two functions
- `date.dayOfWeek(year, month, day)`: calculates the day of the week for a given date (0=Sunday, 1=Monday, etc)
- `date.dayOfYear(year, month, day)`: calculates the ordinal day of the year for a given date (1-355/366, depending on if it's a leap year)

I think there are additional functions that could be added, but this seemed like a good start, especially `date.dayOfWeek` which I could see being used for things like specifying days to do rollouts, or filtering query results by day of the week.