### PR TITLE
chore: render docs with jsonnet native impl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,7 @@ test:
 
 .PHONY: docs
 docs:
-	docsonnet main.libsonnet
+	@rm -rf ./docs; \
+	jb install; \
+	jsonnet -J ./vendor -S -c -m ./docs \
+		--exec "(import 'doc-util/main.libsonnet').render(import 'main.libsonnet')"

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,0 @@
-Gemfile.lock
-_site

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,0 @@
-source "https://rubygems.org"
-gem "github-pages", group: :jekyll_plugins

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,4 @@
----
-permalink: /
----
-
-# package xtd
-
-```jsonnet
-local xtd = import "github.com/jsonnet-libs/xtd/main.libsonnet"
-```
+# xtd
 
 `xtd` aims to collect useful functions not included in the Jsonnet standard library (`std`).
 
@@ -14,11 +6,24 @@ This package serves as a test field for functions intended to be contributed to 
 in the future, but also provides a place for less general, yet useful utilities.
 
 
+## Install
+
+```
+jb install github.com/jsonnet-libs/xtd/main.libsonnet@master
+```
+
+## Usage
+
+```jsonnet
+local xtd = import "github.com/jsonnet-libs/xtd/main.libsonnet"
+```
+
 ## Subpackages
 
-* [aggregate](aggregate.md)
-* [ascii](ascii.md)
-* [camelcase](camelcase.md)
-* [date](date.md)
-* [inspect](inspect.md)
-* [url](url.md)
+* [aggregate](xtd/aggregate.md)
+* [ascii](xtd/ascii.md)
+* [camelcase](xtd/camelcase.md)
+* [date](xtd/date.md)
+* [inspect](xtd/inspect.md)
+* [url](xtd/url.md)
+

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,0 @@
-theme: jekyll-theme-cayman
-baseurl: /xtd

--- a/docs/xtd/aggregate.md
+++ b/docs/xtd/aggregate.md
@@ -1,12 +1,4 @@
----
-permalink: /aggregate/
----
-
-# package aggregate
-
-```jsonnet
-local aggregate = import "github.com/jsonnet-libs/xtd/aggregate.libsonnet"
-```
+# aggregate
 
 `aggregate` implements helper functions to aggregate arrays of objects into objects with arrays.
 
@@ -48,6 +40,18 @@ Output:
 ```
 
 
+## Install
+
+```
+jb install github.com/jsonnet-libs/xtd/aggregate.libsonnet@master
+```
+
+## Usage
+
+```jsonnet
+local aggregate = import "github.com/jsonnet-libs/xtd/aggregate.libsonnet"
+```
+
 ## Index
 
 * [`fn byKey(arr, key)`](#fn-bykey)
@@ -72,3 +76,4 @@ byKeys(arr, keys)
 
 `byKey` aggregates an array by iterating over `keys`, each item in `keys` nests the
 aggregate one layer deeper.
+

--- a/docs/xtd/ascii.md
+++ b/docs/xtd/ascii.md
@@ -1,14 +1,18 @@
----
-permalink: /ascii/
----
+# ascii
 
-# package ascii
+`ascii` implements helper functions for ascii characters
+
+## Install
+
+```
+jb install github.com/jsonnet-libs/xtd/ascii.libsonnet@master
+```
+
+## Usage
 
 ```jsonnet
 local ascii = import "github.com/jsonnet-libs/xtd/ascii.libsonnet"
 ```
-
-`ascii` implements helper functions for ascii characters
 
 ## Index
 

--- a/docs/xtd/camelcase.md
+++ b/docs/xtd/camelcase.md
@@ -1,14 +1,18 @@
----
-permalink: /camelcase/
----
+# camelcase
 
-# package camelcase
+`camelcase` can split camelCase words into an array of words.
+
+## Install
+
+```
+jb install github.com/jsonnet-libs/xtd/camelcase.libsonnet@master
+```
+
+## Usage
 
 ```jsonnet
 local camelcase = import "github.com/jsonnet-libs/xtd/camelcase.libsonnet"
 ```
-
-`camelcase` can split camelCase words into an array of words.
 
 ## Index
 
@@ -27,3 +31,4 @@ digits. Both lower camel case and upper camel case are supported. It only suppor
 ASCII characters.
 For more info please check: http://en.wikipedia.org/wiki/CamelCase
 Based on https://github.com/fatih/camelcase/
+

--- a/docs/xtd/date.md
+++ b/docs/xtd/date.md
@@ -1,14 +1,18 @@
----
-permalink: /date/
----
+# date
 
-# package date
+`time` provides various date related functions.
+
+## Install
+
+```
+jb install github.com/jsonnet-libs/xtd/date.libsonnet@master
+```
+
+## Usage
 
 ```jsonnet
 local date = import "github.com/jsonnet-libs/xtd/date.libsonnet"
 ```
-
-`time` provides various date related functions.
 
 ## Index
 

--- a/docs/xtd/index.md
+++ b/docs/xtd/index.md
@@ -1,0 +1,8 @@
+# xtd
+
+* [aggregate](aggregate.md)
+* [ascii](ascii.md)
+* [camelcase](camelcase.md)
+* [date](date.md)
+* [inspect](inspect.md)
+* [url](url.md)

--- a/docs/xtd/inspect.md
+++ b/docs/xtd/inspect.md
@@ -1,14 +1,18 @@
----
-permalink: /inspect/
----
+# inspect
 
-# package inspect
+`inspect` implements helper functions for inspecting Jsonnet
+
+## Install
+
+```
+jb install github.com/jsonnet-libs/xtd/inspect.libsonnet@master
+```
+
+## Usage
 
 ```jsonnet
 local inspect = import "github.com/jsonnet-libs/xtd/inspect.libsonnet"
 ```
-
-`inspect` implements helper functions for inspecting Jsonnet
 
 ## Index
 
@@ -62,3 +66,4 @@ inspect(object, maxDepth)
 
 `inspect` reports the structure of a Jsonnet object with a recursion depth of
 `maxDepth` (default maxDepth=10).
+

--- a/docs/xtd/url.md
+++ b/docs/xtd/url.md
@@ -1,14 +1,18 @@
----
-permalink: /url/
----
+# url
 
-# package url
+`url` implements URL escaping and query building
+
+## Install
+
+```
+jb install github.com/jsonnet-libs/xtd/url.libsonnet@master
+```
+
+## Usage
 
 ```jsonnet
 local url = import "github.com/jsonnet-libs/xtd/url.libsonnet"
 ```
-
-`url` implements URL escaping and query building
 
 ## Index
 

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": "doc-util"
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": true
+}


### PR DESCRIPTION
Rather than requiring docsonnet to be installed, this renders the docs natively with
jsonnet. It changes directory structure a bit, removes the old github pages stuff and
adds a dependency on doc-util.

Not sure if we want this change.