### PR TITLE
fix(jsonpath): return null instead of recursing

### DIFF
--- a/jsonpath.libsonnet
+++ b/jsonpath.libsonnet
@@ -26,7 +26,9 @@ local d = import 'doc-util/main.libsonnet';
     local _path = self.convertBracketToDot(path);
     std.foldl(
       function(acc, key)
-        get(acc, key, default),
+        if acc == null
+        then acc
+        else get(acc, key, default),
       xtd.string.splitEscape(_path, '.'),
       source,
     ),


### PR DESCRIPTION
When recursing, if `get()` returns `null`, stop recursing.