### PR TITLE
fix(inspect): swap function args for filterObjects

### DIFF
--- a/inspect.libsonnet
+++ b/inspect.libsonnet
@@ -162,7 +162,7 @@ local d = import 'doc-util/main.libsonnet';
       else
         std.foldl(
           function(acc, o)
-            acc + self.filterObjects(x[o], filter_func),
+            acc + self.filterObjects(filter_func, x[o]),
           std.objectFields(x),
           []
         )
@@ -171,7 +171,7 @@ local d = import 'doc-util/main.libsonnet';
       std.flattenArrays(
         std.map(
           function(obj)
-            self.filterObjects(obj, filter_func),
+            self.filterObjects(filter_func, obj),
           x
         )
       )


### PR DESCRIPTION
These arguments were swapped but not where they were used.