### PR TITLE
Add `toCamelCase` function

### DIFF
--- a/camelcase.libsonnet
+++ b/camelcase.libsonnet
@@ -77,4 +77,24 @@ local d = import 'doc-util/main.libsonnet';
         if r != ''
       ],
 
+  '#toCamelCase':: d.fn(
+    |||
+      `toCamelCase` transforms a string to camelCase format, splitting words by the `-`, `_` or spaces.
+      For example: `hello_world` becomes `helloWorld`.
+      For more info please check: http://en.wikipedia.org/wiki/CamelCase
+    |||,
+    [d.arg('str', d.T.string)]
+  ),
+  toCamelCase(str)::
+    local separators = std.set(std.findSubstr('_', str) + std.findSubstr('-', str) + std.findSubstr(' ', str));
+    local n = std.join('', [
+      if std.setMember(i - 1, separators)
+      then std.asciiUpper(str[i])
+      else str[i]
+      for i in std.range(0, std.length(str) - 1)
+      if !std.setMember(i, separators)
+    ]);
+    if std.length(n) == 0
+    then n
+    else std.asciiLower(n[0]) + n[1:],
 }

--- a/docs/camelcase.md
+++ b/docs/camelcase.md
@@ -36,6 +36,6 @@ Based on https://github.com/fatih/camelcase/
 toCamelCase(str)
 ```
 
-`toCamelCase` transforms a string to camelCase format, splitting words by the `-` or `_` separators.
+`toCamelCase` transforms a string to camelCase format, splitting words by the `-`, `_` or spaces.
 For example: `hello_world` becomes `helloWorld`.
 For more info please check: http://en.wikipedia.org/wiki/CamelCase

--- a/docs/camelcase.md
+++ b/docs/camelcase.md
@@ -13,6 +13,7 @@ local camelcase = import "github.com/jsonnet-libs/xtd/camelcase.libsonnet"
 ## Index
 
 * [`fn split(src)`](#fn-split)
+* [`fn toCamelCase(str)`](#fn-tocamelcase)
 
 ## Fields
 
@@ -27,3 +28,14 @@ digits. Both lower camel case and upper camel case are supported. It only suppor
 ASCII characters.
 For more info please check: http://en.wikipedia.org/wiki/CamelCase
 Based on https://github.com/fatih/camelcase/
+
+
+### fn toCamelCase
+
+```ts
+toCamelCase(str)
+```
+
+`toCamelCase` transforms a string to camelCase format, splitting words by the `-` or `_` separators.
+For example: `hello_world` becomes `helloWorld`.
+For more info please check: http://en.wikipedia.org/wiki/CamelCase

--- a/test/camelcase_test.jsonnet
+++ b/test/camelcase_test.jsonnet
@@ -4,115 +4,171 @@ local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
 test.new(std.thisFile)
 
 + test.case.new(
-  name='nostring',
+  name='split: nostring',
   test=test.expect.eq(
     actual=xtd.camelcase.split(''),
     expected=[''],
   )
 )
 + test.case.new(
-  name='lowercase',
+  name='split: lowercase',
   test=test.expect.eq(
     actual=xtd.camelcase.split('lowercase'),
     expected=['lowercase'],
   )
 )
 + test.case.new(
-  name='Class',
+  name='split: Class',
   test=test.expect.eq(
     actual=xtd.camelcase.split('Class'),
     expected=['Class'],
   )
 )
 + test.case.new(
-  name='MyClass',
+  name='split: MyClass',
   test=test.expect.eq(
     actual=xtd.camelcase.split('MyClass'),
     expected=['My', 'Class'],
   )
 )
 + test.case.new(
-  name='MyC',
+  name='split: MyC',
   test=test.expect.eq(
     actual=xtd.camelcase.split('MyC'),
     expected=['My', 'C'],
   )
 )
 + test.case.new(
-  name='HTML',
+  name='split: HTML',
   test=test.expect.eq(
     actual=xtd.camelcase.split('HTML'),
     expected=['HTML'],
   )
 )
 + test.case.new(
-  name='PDFLoader',
+  name='split: PDFLoader',
   test=test.expect.eq(
     actual=xtd.camelcase.split('PDFLoader'),
     expected=['PDF', 'Loader'],
   )
 )
 + test.case.new(
-  name='AString',
+  name='split: AString',
   test=test.expect.eq(
     actual=xtd.camelcase.split('AString'),
     expected=['A', 'String'],
   )
 )
 + test.case.new(
-  name='SimpleXMLParser',
+  name='split: SimpleXMLParser',
   test=test.expect.eq(
     actual=xtd.camelcase.split('SimpleXMLParser'),
     expected=['Simple', 'XML', 'Parser'],
   )
 )
 + test.case.new(
-  name='vimRPCPlugin',
+  name='split: vimRPCPlugin',
   test=test.expect.eq(
     actual=xtd.camelcase.split('vimRPCPlugin'),
     expected=['vim', 'RPC', 'Plugin'],
   )
 )
 + test.case.new(
-  name='GL11Version',
+  name='split: GL11Version',
   test=test.expect.eq(
     actual=xtd.camelcase.split('GL11Version'),
     expected=['GL', '11', 'Version'],
   )
 )
 + test.case.new(
-  name='99Bottles',
+  name='split: 99Bottles',
   test=test.expect.eq(
     actual=xtd.camelcase.split('99Bottles'),
     expected=['99', 'Bottles'],
   )
 )
 + test.case.new(
-  name='May5',
+  name='split: May5',
   test=test.expect.eq(
     actual=xtd.camelcase.split('May5'),
     expected=['May', '5'],
   )
 )
 + test.case.new(
-  name='BFG9000',
+  name='split: BFG9000',
   test=test.expect.eq(
     actual=xtd.camelcase.split('BFG9000'),
     expected=['BFG', '9000'],
   )
 )
 + test.case.new(
-  name='Two  spaces',
+  name='split: Two  spaces',
   test=test.expect.eq(
     actual=xtd.camelcase.split('Two  spaces'),
     expected=['Two', '  ', 'spaces'],
   )
 )
 + test.case.new(
-  name='Multiple   Random  spaces',
+  name='split: Multiple   Random  spaces',
   test=test.expect.eq(
     actual=xtd.camelcase.split('Multiple   Random  spaces'),
     expected=['Multiple', '   ', 'Random', '  ', 'spaces'],
+  )
+)
++ test.case.new(
+  name='toCamelCase: empty string',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase(''),
+    expected='',
+  )
+)
++ test.case.new(
+  name='toCamelCase: lowercase',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase('lowercase'),
+    expected='lowercase',
+  )
+)
++ test.case.new(
+  name='toCamelCase: underscores',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase('lower_case'),
+    expected='lowerCase',
+  )
+)
++ test.case.new(
+  name='toCamelCase: dashes',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase('lower-case'),
+    expected='lowerCase',
+  )
+)
++ test.case.new(
+  name='toCamelCase: spaces',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase('lower case'),
+    expected='lowerCase',
+  )
+)
++ test.case.new(
+  name='toCamelCase: mixed',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase('lower_case-mixed'),
+    expected='lowerCaseMixed',
+  )
+)
++ test.case.new(
+  name='toCamelCase: multiple spaces',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase('lower  case'),
+    expected='lowerCase',
+  )
+)
++ test.case.new(
+  name='toCamelCase: PascalCase',
+  test=test.expect.eq(
+    actual=xtd.camelcase.toCamelCase('PascalCase'),
+    expected='pascalCase',
   )
 )
 


### PR DESCRIPTION
This transforms a dash or underscore separated string to camelCase 
Added a bunch of tests and ran `make docs`

Will be used here: https://github.com/crdsonnet/crdsonnet/pull/17