### PR TITLE
Add an example of RFC3339 date to `date.parseRFC3339` comment

### DIFF
--- a/date.libsonnet
+++ b/date.libsonnet
@@ -146,7 +146,7 @@ local d = import 'doc-util/main.libsonnet';
 
   '#parseRFC3339': d.fn(
     |||
-      `parseRFC3339` parses an RFC3339-formatted date & time string into an object containing the 'year', 'month', 'day', 'hour', 'minute' and 'second fields.
+      `parseRFC3339` parses an RFC3339-formatted date & time string (like `2020-01-02T03:04:05Z`) into an object containing the 'year', 'month', 'day', 'hour', 'minute' and 'second fields.
       This is a limited implementation that does not support timezones (so it requires an UTC input ending in 'Z' or 'z') nor sub-second precision.
       The returned object has a `toUnixTimestamp()` method that can be used to obtain the unix timestamp of the parsed date.
     |||,

--- a/docs/date.md
+++ b/docs/date.md
@@ -52,7 +52,7 @@ isLeapYear(year)
 parseRFC3339(input)
 ```
 
-`parseRFC3339` parses an RFC3339-formatted date & time string into an object containing the 'year', 'month', 'day', 'hour', 'minute' and 'second fields.
+`parseRFC3339` parses an RFC3339-formatted date & time string (like `2020-01-02T03:04:05Z`) into an object containing the 'year', 'month', 'day', 'hour', 'minute' and 'second fields.
 This is a limited implementation that does not support timezones (so it requires an UTC input ending in 'Z' or 'z') nor sub-second precision.
 The returned object has a `toUnixTimestamp()` method that can be used to obtain the unix timestamp of the parsed date.
 


### PR DESCRIPTION
Addressing the pending comment from https://github.com/jsonnet-libs/xtd/pull/23#discussion_r1379797201